### PR TITLE
Correctly define multiline string for cache-to

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,4 +72,4 @@ jobs:
             spacestationnt/ssnt:cache
           cache-to: |
             type=gha,mode=max
-            type=registry,ref=spacestationnt/ssnt:cache,mode=max
+            ${{ github.event_name == 'push' && 'type=registry,ref=spacestationnt/ssnt:cache,mode=max' || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,6 @@ jobs:
           cache-from: |
             type=gha
             spacestationnt/ssnt:cache
-          cache-to:
+          cache-to: |
             type=gha,mode=max
             type=registry,ref=spacestationnt/ssnt:cache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ WORKDIR /build
 FROM chef AS planner
 
 RUN : \
-    && apk upgrade \
-    && apk add \
+    && apk add --no-cache \
         # Ctrl+C handler
         dumb-init
 


### PR DESCRIPTION
This seem to be the reason why `cache` tag is not on docker hub 