### PR TITLE
add .gz to archive extension

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,8 @@ jobs:
         platform: [linux, windows]
         include:
           - platform: linux
-            archive-command: tar zcvf ssnt.tar
-            output-path: ssnt.tar
+            archive-command: tar zcvf ssnt.tar.gz
+            output-path: ssnt.tar.gz
           - platform: windows
             archive-command: zip -r ssnt.zip
             output-path: ssnt.zip


### PR DESCRIPTION
`z` flag adds gzip compression. `tar.gz` is correct extension