### PR TITLE
dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,12 @@ COPY crates crates
 
 RUN cargo build --release --no-default-features
 
-FROM scratch
+FROM scratch as runtime
+
+ENV RUST_BACKTRACE=full
 
 COPY --from=builder /build/target/release/ssnt .
 COPY --from=planner /usr/bin/dumb-init .
 COPY assets assets
 
-ENTRYPOINT ["./dumb-init", "--", "./ssnt", "host"]
+ENTRYPOINT ["./dumb-init", "--", "./ssnt", "host", "0.0.0.0:33998"]

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ ssnt.exe host 127.0.0.1:33998
 
 Or using docker:
 
-```
-docker run -p 33998:33998/tcp -p 33998:33998/udp spacestationnt/ssnt 0.0.0.0:33998 --public-address 127.0.0.1
+```sh
+docker run -p 33998:33998/udp spacestationnt/ssnt --public-address 127.0.0.1
 ```
 
 Then join your server with a client:


### PR DESCRIPTION
moved 0.0.0.0 bind into entrypoint since there is no reason to change it, enabled RUST_BACKTRACE=full, no reason to expose tcp port